### PR TITLE
Add new relic monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
@@ -48,6 +52,11 @@
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.newrelic.telemetry</groupId>
+			<artifactId>micrometer-registry-new-relic</artifactId>
+			<version>0.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/com/example/demo/configs/MicrometerConfig.java
+++ b/src/main/java/com/example/demo/configs/MicrometerConfig.java
@@ -1,0 +1,80 @@
+package com.example.demo.configs;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.micrometer.NewRelicRegistry;
+import com.newrelic.telemetry.micrometer.NewRelicRegistryConfig;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+
+@Configuration
+@AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class})
+@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@ConditionalOnClass(NewRelicRegistry.class)
+@Profile("!test")
+public class MicrometerConfig {
+
+    @Bean
+    public NewRelicRegistryConfig newRelicConfig() {
+
+        return new NewRelicRegistryConfig() {
+
+            @Value("${management.newrelic.metrics.export.api-key}")
+            private String newRelicApiKey;
+            @Value("${management.newrelic.metrics.export.uri}")
+            private String newRelicUri;
+            @Value("${spring.application.name}")
+            private String applicationName;
+
+            @Override
+            public String get(@NonNull String key) {
+                return null;
+            }
+
+            @Override
+            public String apiKey() {
+                return newRelicApiKey;
+            }
+
+            @Override
+            public String uri() {
+                return newRelicUri;
+            }
+
+            @Override
+            public @NonNull Duration step() {
+                return Duration.ofSeconds(5);
+            }
+
+            @Override
+            public String serviceName() {
+                return applicationName;
+            }
+        };
+    }
+
+    @Bean
+    public NewRelicRegistry newRelicMeterRegistry(NewRelicRegistryConfig config) throws UnknownHostException {
+        NewRelicRegistry newRelicRegistry = NewRelicRegistry.builder(config)
+                .commonAttributes(new Attributes().put("host", InetAddress.getLocalHost().getHostName()))
+                .build();
+        newRelicRegistry.config().meterFilter(MeterFilter.ignoreTags("plz_ignore_me"));
+        newRelicRegistry.config().meterFilter(MeterFilter.denyNameStartsWith("jvm.threads"));
+        newRelicRegistry.start(new NamedThreadFactory("newrelic.micrometer.registry"));
+        return newRelicRegistry;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,7 @@ spring.data.redis.port=${redis.port}
 # ------------------------------------------------------------------
 # Spring
 # ------------------------------------------------------------------
+spring.application.name=DemoApplication
 spring.jpa.open-in-view=true
 
 

--- a/src/test/java/com/example/demo/services/UserServiceCachingPerformanceTest.java
+++ b/src/test/java/com/example/demo/services/UserServiceCachingPerformanceTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -29,6 +30,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
 @EnableCaching
 @SpringBootTest
+@ActiveProfiles("test")
 public class UserServiceCachingPerformanceTest {
 
     @Autowired

--- a/src/test/java/com/example/demo/services/UserServiceJpaTest.java
+++ b/src/test/java/com/example/demo/services/UserServiceJpaTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import static com.example.demo.services.util.UserServiceTestUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @ComponentScan(basePackages = {"com.example.demo.services"})
 public class UserServiceJpaTest {
 

--- a/src/test/java/com/example/demo/services/UserServiceRedisTest.java
+++ b/src/test/java/com/example/demo/services/UserServiceRedisTest.java
@@ -18,6 +18,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.ApplicationContext;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @EnableCaching
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase
 public class UserServiceRedisTest {
 

--- a/src/test/java/com/example/demo/services/UserServiceTransactionalTest.java
+++ b/src/test/java/com/example/demo/services/UserServiceTransactionalTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.ActiveProfiles;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -24,6 +25,7 @@ import static com.example.demo.services.util.UserServiceTestUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase
 public class UserServiceTransactionalTest {
 


### PR DESCRIPTION
- Added `MicrometerConfig` as configuration class for New Relic’s Micrometer. Configuring is not performing when using `test` profile.
- Added dependencies for using New Relic’s Micrometer.
- Set `test` as active profile for all test classes to prevent usage of New Relic monitoring.